### PR TITLE
fix: Updated the Docs

### DIFF
--- a/en/starter/installing.md
+++ b/en/starter/installing.md
@@ -42,7 +42,7 @@ To install Express temporarily and not add it to the dependencies list:
 ```sh
 $ npm install express --no-save
 ```
-Or, simply: (**i** = install)
+Or, simply: (**i** = Install)
 ```sh
 $ npm i express
 ```


### PR DESCRIPTION
Added a command for installing express as it's the most widely used command for installing Express(in all the tutorials I have seen till now! )
![Screenshot 2021-11-21 at 2 28 09 PM](https://user-images.githubusercontent.com/58332678/142756054-69011508-73f8-46c1-bced-dbcd814f848e.png)
